### PR TITLE
添加loop处代码缺少的"end"

### DIFF
--- a/README-zhCN.md
+++ b/README-zhCN.md
@@ -807,6 +807,7 @@
     # 好
     loop do
       do_something
+    end
     ```
 
 * 循环后条件判断使用 `Kernel#loop` 和 `break`，而不是 `begin/end/until` 或者 `begin/end/while`。


### PR DESCRIPTION
在无限循环应该使用loop而非while/until的地方，loop的示范代码缺少了end。